### PR TITLE
Force plugins commands to be sent first

### DIFF
--- a/continuousprint/__init__.py
+++ b/continuousprint/__init__.py
@@ -184,7 +184,7 @@ class ContinuousprintPlugin(octoprint.plugin.SettingsPlugin,
 		self.enabled = False # Set enabled to false
 		self._plugin_manager.send_plugin_message(self._identifier, dict(type="complete", msg="Print Queue Complete"))
 		queue_finished_script = self._settings.get(["cp_queue_finished"]).split("\n")
-		self._printer.commands(self.parse_gcode(queue_finished_script))#send queue finished script to the printer
+		self._printer.commands(self.parse_gcode(queue_finished_script,force=True))#send queue finished script to the printer
 		
 		
 

--- a/continuousprint/__init__.py
+++ b/continuousprint/__init__.py
@@ -178,7 +178,7 @@ class ContinuousprintPlugin(octoprint.plugin.SettingsPlugin,
 	def clear_bed(self):
 		self._logger.info("Clearing bed")
 		bed_clearing_script=self._settings.get(["cp_bed_clearing_script"]).split("\n")	
-		self._printer.commands(self.parse_gcode(bed_clearing_script))
+		self._printer.commands(self.parse_gcode(bed_clearing_script),force=True)
 		
 	def complete_queue(self):
 		self.enabled = False # Set enabled to false

--- a/continuousprint/static/css/continuousprint.css
+++ b/continuousprint/static/css/continuousprint.css
@@ -21,7 +21,7 @@
 #tab_plugin_continuousprint .count-box{
   min-width:30px;
   max-width: 30px; 
-  max-height:8px;
+  max-height:18px;
   
 }
 #tab_plugin_continuousprint .file-name{

--- a/continuousprint/static/css/continuousprint.css
+++ b/continuousprint/static/css/continuousprint.css
@@ -21,15 +21,15 @@
 #tab_plugin_continuousprint .count-box{
   min-width:30px;
   max-width: 30px; 
-  max-height:16px;
+  max-height:15px;
   
 }
-#tab_plugin_continuousprint .file-name{
-  flex-shrink: 10; 
-  overflow-x:scroll;
-  white-space: nowrap;
-  max-width:96%;
-  
+#tab_plugin_continuousprint .file-name {
+    flex-shrink: 10;
+    overflow-x: scroll;
+    white-space: nowrap;
+    max-width: 96%;
+    padding-top: 1px;
 }
 #tab_plugin_continuousprint .end-bundle{
   flex-grow:2;

--- a/continuousprint/static/css/continuousprint.css
+++ b/continuousprint/static/css/continuousprint.css
@@ -21,7 +21,7 @@
 #tab_plugin_continuousprint .count-box{
   min-width:30px;
   max-width: 30px; 
-  max-height:18px;
+  max-height:16px;
   
 }
 #tab_plugin_continuousprint .file-name{


### PR DESCRIPTION
Perhaps octoprint has begun sending the first lines of the next print(homing) before the bed clearing script?
