### PR TITLE
Fix OctoPrint Continuously Prompting for Update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "continuousprint"
 plugin_name = "continuousprint"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.2.2"
+plugin_version = "1.2.3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Updated version number to 1.2.3 to fix OctoPrint Continuously Prompting for Update.