### PR TITLE
Fix parsing of "SD" field in storage

### DIFF
--- a/continuousprint/print_queue.py
+++ b/continuousprint/print_queue.py
@@ -6,6 +6,8 @@ class QueueItem:
     def __init__(self, name, path, sd, start_ts=None, end_ts=None, result=None, retries=0):
         self.name = name
         self.path = path
+        if type(sd) == str:
+            sd = (sd.lower() == "true")
         if type(sd) != bool:
             raise Exception("SD must be bool, got %s" % (type(sd)))
         self.sd = sd

--- a/continuousprint/print_queue_test.py
+++ b/continuousprint/print_queue_test.py
@@ -8,7 +8,7 @@ test_items = [
     QueueItem("bar", "/bar.gco", True, end_ts=456),
     QueueItem("baz", "/baz.gco", True),
     QueueItem("boz", "/boz.gco", True),
-    QueueItem("foz", "/foz.gco", True),
+    QueueItem("foz", "/foz.gco", "True"), # Older versions of the plugin may have string bool values
 ]
 
 class TestPrintQueue(unittest.TestCase):


### PR DESCRIPTION
#53 has logs displaying

```
Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/plugin/__init__.py", line 271, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/util/__init__.py", line 1737, in wrapper
    return f(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/continuousprint/__init__.py", line 75, in on_after_startup
    self.q = PrintQueue(self._settings, QUEUE_KEY)
  File "/home/pi/oprint/lib/python3.7/site-packages/continuousprint/print_queue.py", line 33, in __init__
    self._load()
  File "/home/pi/oprint/lib/python3.7/site-packages/continuousprint/print_queue.py", line 54, in _load
    retries = v.get("retries", 0),
  File "/home/pi/oprint/lib/python3.7/site-packages/continuousprint/print_queue.py", line 10, in __init__
    raise Exception("SD must be bool, got %s" % (type(sd)))
Exception: SD must be bool, got <class 'str'>
```

I suspect this is some leftover "old" storage format issues from the prior version of the plugin. This PR does a quick "cast" from string to bool to prevent the plugin from failing to initialize (which causes `500` http errors later on) 